### PR TITLE
Removes initial steps required to run in development environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ public/components
 .sass-cache
 config/development.js
 .DS_Store
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ node_modules/
 public/components
 .nyc_output
 .sass-cache
-config/development.js
 .DS_Store
 .idea

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ cd band-website
 npm i
 ```
 #### Run in development
-1. [Log in to Cosmic JS](https://cosmicjs.com).
 
 ```
 npm run dev

--- a/README.md
+++ b/README.md
@@ -10,9 +10,21 @@ cd band-website
 npm i
 ```
 #### Run in development
+1. [Log in to Cosmic JS](https://cosmicjs.com).
+
 ```
 npm run dev
+
 ```
+
+You can easily access content from your Cosmic JS Bucket.
+1. [Log in to Cosmic JS](https://cosmicjs.com).
+2. Create a Bucket.
+3. Go to your Bucket dashboard and find the Settings > Basic Settings menu.
+4. Generate keys for Read/Write access for this bucket.
+5. Safely store these secrets as env variables to be accessed for local development: `COSMIC_READ_KEY` and `COSMIC_WRITE_KEY`
+6. Now when you run `npm run dev` you should see content from your bucket hydrating your views. 
+
 #### Run in production
 ```
 COSMIC_BUCKET=your-bucket-slug npm start

--- a/config/development.js
+++ b/config/development.js
@@ -1,0 +1,7 @@
+module.exports = {
+    bucket: {
+        slug: process.env.COSMIC_BUCKET,
+        read_key: process.env.COSMIC_READ_KEY,
+        write_key: process.env.COSMIC_WRITE_KEY
+    }
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,7 +6,7 @@ const _ = require('lodash')
 const axios = require('axios')
 const config = require('../config')
 const api = Cosmic()
-const bucket = api.bucket({ slug: config.bucket.slug })
+const bucket = api.bucket(config.bucket)
 
 router.get('/', (req, res) => {
   async.series({


### PR DESCRIPTION
- Update `README.md` with instructions for configuring dev environment
- Pass entire bucket object from `config/` to bucket api call (If we don't pass the `COSMIC_READ_ACCESS` value access via `config`, the dev environment cannot read bucket data. This change allows the dev environment views to be hydrated with bucket content)
- Added `development.js` to `config/`, removed from `.gitignore`
- `development.js` is expected by the `dev` npm script.
- We should include the file in the repo (it looks just like production.js) and add instructions for using it. In other words, this PR will help cut the number of steps required to configure local development environment.
- Added .idea directory to `.gitignore`